### PR TITLE
Add FastTelethon 🚀

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "FastTelethon"]
+	path = FastTelethon
+	url = https://gist.github.com/painor/7e74de80ae0c819d3e9abcf9989a8dd6


### PR DESCRIPTION
封面我就不做了（send_file 里加 thumb），可能要用到 ffmpeg（据我观察，视频文件大过 10MB 可以用自己的封面）
目前 mkv mp4 都能以 视频 的状态发给用户，能不能播就是客户端的问题了

这个 FastTelethon 我没怎么试大文件，不知道会不会 rateLimit（上一次用的时候都快一年了）

DC5 上传最慢的，不过 DC1 上传最快（其他的没试，估计 DC5 最慢）
（下载又另外一回事了）