### PR TITLE
compatibility improvement

### DIFF
--- a/ytdl.py
+++ b/ytdl.py
@@ -92,7 +92,8 @@ def ytdl_download(url, tempdir, chat_id, message) -> dict:
     ydl_opts = {
         'progress_hooks': [lambda d: progress_hook(d, chat_id, message)],
         'outtmpl': output,
-        'restrictfilenames': True
+        'restrictfilenames': True,
+        'format': 'bestvideo[vcodec^=avc]+bestaudio[acodec^=mp4a]/best'
     }
     try:
         with youtube_dl.YoutubeDL(ydl_opts) as ydl:


### PR DESCRIPTION
目前默认下下来的是H264+Opus的mkv, iPhone/iPad没法直接播放，如果缺少ffmpeg的话就会选择为720p带音频的mp4, 指定一下选用最佳的mp4（不带音频）和m4a, 就能合成mp4, 解决上述问题。记得在deploy里提醒一下要装ffmpeg.